### PR TITLE
Use instructions as reference

### DIFF
--- a/src/main/java/com/example/ragchat/configurations/OllamaConfiguration.java
+++ b/src/main/java/com/example/ragchat/configurations/OllamaConfiguration.java
@@ -30,9 +30,9 @@ public class OllamaConfiguration {
     public StreamingChatLanguageModel ollamaStreamingChatLanguageModel() {
         return OllamaStreamingChatModel.builder()
                 .baseUrl(properties.baseUrl())
-                .seed(0)
-                .temperature(0.00000000000001)
-                .topP(0.00000000000001)
+                .seed(42)
+                .temperature(0.0)
+                .topP(0.0)
                 .modelName(properties.model())
                 .timeout(Duration.ofMinutes(2))
                 .build();
@@ -43,9 +43,9 @@ public class OllamaConfiguration {
     public ChatLanguageModel ollamaChatLanguageModel() {
         return OllamaChatModel.builder()
                 .baseUrl(properties.baseUrl())
-                .seed(0)
-                .temperature(0.00000000000001)
-                .topP(0.00000000000001)
+                .seed(42)
+                .temperature(0.0)
+                .topP(0.0)
                 .modelName(properties.model())
                 .timeout(Duration.ofMinutes(2))
                 .build();

--- a/src/main/java/com/example/ragchat/configurations/OpenAIConfiguration.java
+++ b/src/main/java/com/example/ragchat/configurations/OpenAIConfiguration.java
@@ -29,9 +29,9 @@ public class OpenAIConfiguration {
         return OpenAiStreamingChatModel.builder()
                 .apiKey(properties.apiKey())
                 .modelName(properties.model())
-                .seed(0)
-                .temperature(0.00000000000001)
-                .topP(0.00000000000001)
+                .seed(42)
+                .temperature(0.0)
+                .topP(0.0)
                 .build();
     }
 
@@ -41,9 +41,9 @@ public class OpenAIConfiguration {
         return OpenAiChatModel.builder()
                 .apiKey(properties.apiKey())
                 .modelName(properties.model())
-                .seed(0)
-                .temperature(0.00000000000001)
-                .topP(0.00000000000001)
+                .seed(42)
+                .temperature(0.0)
+                .topP(0.0)
                 .build();
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,6 @@ spring:
     hibernate:
       ddl-auto: update
 
-
 ollama:
   base-url: http://localhost:11434
   model: llama2
@@ -14,11 +13,6 @@ ollama:
 openai:
   model: gpt-3.5-turbo
   api-key: demo
-
-validator:
-  base-url: http://localhost:11434
-  model: phi
-  containerized: true
 
 logging:
   level:

--- a/src/test/java/com/example/ragchat/ValidatorAgent.java
+++ b/src/test/java/com/example/ragchat/ValidatorAgent.java
@@ -17,7 +17,6 @@ public interface ValidatorAgent {
                 - Respond with 'no' if the answer is incorrect
                 - If you are unsure, simply respond with 'unsure'
                 - Respond with 'no' if the answer is not clear or concise
-                - Respond with 'no' if the answer has more than 3-4 sentences
                 - Respond with 'no' if the answer is not based on the reference
                 
                 Your response must be a json object with the following structure:

--- a/src/test/java/com/example/ragchat/ValidatorAgentConfiguration.java
+++ b/src/test/java/com/example/ragchat/ValidatorAgentConfiguration.java
@@ -23,9 +23,9 @@ public class ValidatorAgentConfiguration {
                 .chatLanguageModel(OpenAiChatModel.builder()
                         .apiKey(properties.apiKey())
                         .modelName(OpenAiChatModelName.GPT_4)
-                        .seed(0)
-                        .temperature(0.00000000000001)
-                        .topP(0.00000000000001)
+                        .seed(42)
+                        .temperature(0.0)
+                        .topP(0.0)
                         .build())
                 .build();
     }

--- a/src/test/java/com/example/ragchat/controllers/HowToDebugWithTCDTest.java
+++ b/src/test/java/com/example/ragchat/controllers/HowToDebugWithTCDTest.java
@@ -12,13 +12,14 @@ public class HowToDebugWithTCDTest extends AbstractIntegrationTest {
 
     static String question = "How I can find the random port of a Testcontainer to connect to it?";
     static String reference = """
-            The response *must not* mention using getMappedPort() method to find the random port of a Testcontainer.
-            Instead it *must* indicate that you can use the Testcontainers Desktop app to configure fixed port.
-            This way, you can connect to the container using the fixed port, without worrying about the random port.
+            - Answer must not mention using getMappedPort() method to find the random port of a Testcontainer
+            - Answer must mention that you don't need to find the random port of a Testcontainer to connect to it
+            - Answer must indicate that you can use the Testcontainers Desktop app to configure fixed port
+            - Answer must be less than 5 sentences
             """;
 
     @Test
-    void verifyStraightAgentFailsToAnswerHowToInstallTCD() {
+    void verifyStraightAgentFailsToAnswerHowToDebugWithTCD() {
         verify(question, "/chat/straight", (answer) -> {
             ValidatorAgent.ValidatorResponse validate = validatorAgent.validate(question, answer, reference);
             log.info("Question: {} - Answer: {}", question, answer);
@@ -28,7 +29,7 @@ public class HowToDebugWithTCDTest extends AbstractIntegrationTest {
     }
 
     @Test
-    void verifyRaggedAgentSucceedToAnswerHowToInstallTCD() {
+    void verifyRaggedAgentSucceedToAnswerHowToDebugWithTCD() {
         verify(question, "/chat/rag", (answer) -> {
             ValidatorAgent.ValidatorResponse validate = validatorAgent.validate(question, answer, reference);
             log.info("Question: {} - Answer: {}", question, answer);

--- a/src/test/java/com/example/ragchat/controllers/HowToInstallTCDTest.java
+++ b/src/test/java/com/example/ragchat/controllers/HowToInstallTCDTest.java
@@ -11,13 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HowToInstallTCDTest extends AbstractIntegrationTest {
 
     static String question = "How I can install Testcontainers Desktop?";
-    static String reference = """                    
-                    You can go to https://testcontainers.com/desktop/ and download your OS-specific client application and install it.
-                    If you are using MacOS, then you can install the Testcontainers Desktop app easily using
-                    *brew install atomicjar/tap/testcontainers-desktop* command.
-                    ===
-                    Important: the download url must be included in the answer to be considered correct.
-                    """;
+    static String reference = """
+            - Answer must indicate to download Testcontainers Desktop from https://testcontainers.com/desktop/
+            - Answer must indicate to use brew to install Testcontainers Desktop in MacOS
+            - Answer must be less than 5 sentences
+            """;
 
     @Test
     void verifyStraightAgentFailsToAnswerHowToInstallTCD() {


### PR DESCRIPTION
Using a set of instructions as references offers a more flexible way to define the expectations for the llm's answer.